### PR TITLE
修复`AxiosResponse`不能获取到`AxiosRequestConfig`的 BUG

### DIFF
--- a/src/adapters.js
+++ b/src/adapters.js
@@ -29,11 +29,11 @@ const uniAdapter = (config) => {
     uni.request({
       ...uniConfig,
       success(res) {
-        const response = getResponse(res);
+        const response = getResponse(res, config);
         resolve(response, config);
       },
       fail(res) {
-        const response = getResponse(res);
+        const response = getResponse(res, config);
         reject(response, config);
       },
     });


### PR DESCRIPTION
`axios`响应拦截器中无法获取到`config`，此提交修复了这个问题。 fixes #4 